### PR TITLE
rename memory adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Initial support is offered for the following (with more to follow soon):
     - An adapter is provided for Steamship's SERPAPI integration (`SteamshipSERP`)
 - Memory
   - Two adapters that provide persistent conversation memory:
-    - Windowed Memory (`SteamshipPersistentConversationMemory`)
-    - Complete Memory (`SteamshipPersistentConversationWindowMemory`)
+    - Complete Memory (`steamship_langchain.memory.ConversationalBufferMemory`)
+    - Windowed Memory (`steamship_langchain.memory.ConversationalBufferWindowMemory`)
 
 ## Example Use Cases
 
@@ -128,11 +128,13 @@ Implements a basic Chatbot (similar to ChatGPT) in Steamship with LangChain (ful
 #### Server Snippet
 
 ```python
+from steamship_langchain.memory import ConversationalBufferWindowMemory
+
 @post("/send_message")
 def send_message(self, message: str, chat_history_handle: str) -> str:
-    mem = SteamshipPersistentConversationWindowMemory(client=self.client,
-                                                      file_handle=chat_history_handle,
-                                                      k=2)
+    mem = ConversationalBufferWindowMemory(client=self.client,
+                                           key=chat_history_handle,
+                                           k=2)
     chatgpt = LLMChain(
         llm=SteamshipGPT(client=self.client, temperature=0), 
         prompt=CHATBOT_PROMPT, 

--- a/examples/chatbot/server/api.py
+++ b/examples/chatbot/server/api.py
@@ -3,10 +3,7 @@ from prompt import CHATBOT_PROMPT
 from steamship.invocable import PackageService, get, post
 
 from steamship_langchain.llms import SteamshipGPT
-from steamship_langchain.memory import (
-    SteamshipPersistentConversationMemory,
-    SteamshipPersistentConversationWindowMemory,
-)
+from steamship_langchain.memory import ConversationalBufferWindowMemory, ConversationBufferMemory
 
 
 class ChatbotPackage(PackageService):
@@ -15,7 +12,7 @@ class ChatbotPackage(PackageService):
         """Returns an AI-generated response to a user conversation, based on limited prior context."""
 
         # steamship_memory will persist/retrieve conversation across API calls
-        steamship_memory = SteamshipPersistentConversationWindowMemory(
+        steamship_memory = ConversationalBufferWindowMemory(
             client=self.client, file_handle=chat_history_handle, k=2
         )
         chatgpt = LLMChain(
@@ -30,7 +27,7 @@ class ChatbotPackage(PackageService):
         """Return the full transcript for a chat session."""
 
         # we can use the non-windowed memory to retrieve the full history.
-        steamship_memory = SteamshipPersistentConversationMemory(
+        steamship_memory = ConversationBufferMemory(
             client=self.client, file_handle=chat_history_handle
         )
 

--- a/src/steamship_langchain/memory/__init__.py
+++ b/src/steamship_langchain/memory/__init__.py
@@ -1,12 +1,9 @@
 """Provides Steamship-compatible wrappers for persistent Memory constructs that can be used in langchain (🦜️🔗) chains
 and agents."""
 
-from .conversation_memory import (
-    SteamshipPersistentConversationMemory,
-    SteamshipPersistentConversationWindowMemory,
-)
+from .conversation_memory import ConversationalBufferWindowMemory, ConversationBufferMemory
 
 __all__ = [
-    "SteamshipPersistentConversationMemory",
-    "SteamshipPersistentConversationWindowMemory",
+    "ConversationBufferMemory",
+    "ConversationalBufferWindowMemory",
 ]

--- a/src/steamship_langchain/memory/conversation_memory.py
+++ b/src/steamship_langchain/memory/conversation_memory.py
@@ -36,11 +36,12 @@ def _block_sort_key(block: Block) -> str:
     ][0]
 
 
-class SteamshipPersistentConversationMemory(Memory):
-    """Stores conversations in a Steamship File, providing persistent storage of the conversation."""
+class ConversationBufferMemory(Memory):
+    """Stores conversations in a Steamship File (instead of a buffer str), providing persistent storage of the
+    conversation."""
 
     client: Steamship
-    file_handle: str
+    key: str
 
     human_prefix: str = "Human"
     ai_prefix: str = "AI"
@@ -93,11 +94,11 @@ class SteamshipPersistentConversationMemory(Memory):
         convo_file = self._get_conversation_file()
         if convo_file:
             return convo_file
-        return File.create(self.client, handle=self.file_handle, blocks=[])
+        return File.create(self.client, handle=self.key, blocks=[])
 
     def _get_conversation_file(self) -> Optional[File]:
         try:
-            return File.get(self.client, handle=self.file_handle)
+            return File.get(self.client, handle=self.key)
         except SteamshipError:
             return None
 
@@ -107,7 +108,7 @@ class SteamshipPersistentConversationMemory(Memory):
             convo_file.delete()
 
 
-class SteamshipPersistentConversationWindowMemory(SteamshipPersistentConversationMemory):
+class ConversationalBufferWindowMemory(ConversationBufferMemory):
     """Stores conversations in a Steamship File, providing persistent storage of the conversation, returning only the
     last k snippets of the conversation.
     """

--- a/tests/memory/test_conversation_memory.py
+++ b/tests/memory/test_conversation_memory.py
@@ -1,10 +1,7 @@
 import pytest
 from steamship import Steamship
 
-from steamship_langchain.memory import (
-    SteamshipPersistentConversationMemory,
-    SteamshipPersistentConversationWindowMemory,
-)
+from steamship_langchain.memory import ConversationalBufferWindowMemory, ConversationBufferMemory
 
 TEST_PROMPT = "this is a test: "
 LLM_STRING = "llm"
@@ -15,9 +12,7 @@ UNKNOWN = "unknown"
 def test_persistent_memory(client: Steamship):
     # example responses heavily borrowed from:
     # https://langchain.readthedocs.io/en/latest/modules/memory/examples/chatgpt_clone.html
-    memory_under_test = SteamshipPersistentConversationMemory(
-        client=client, file_handle="user-1234-session-1"
-    )
+    memory_under_test = ConversationBufferMemory(client=client, key="user-1234-session-1")
 
     memory_variables = memory_under_test.load_memory_variables(inputs={})
     assert len(memory_variables) == 1
@@ -130,8 +125,8 @@ round-trip min/avg/max/stddev = 14.945/14.945/14.945/0.000 ms
 def test_persistent_window_memory(client: Steamship):
     # example responses heavily borrowed from:
     # https://langchain.readthedocs.io/en/latest/modules/memory/examples/chatgpt_clone.html
-    memory_under_test = SteamshipPersistentConversationWindowMemory(
-        client=client, file_handle="user-1234-session-2", k=2
+    memory_under_test = ConversationalBufferWindowMemory(
+        client=client, key="user-1234-session-2", k=2
     )
 
     memory_variables = memory_under_test.load_memory_variables(inputs={})


### PR DESCRIPTION
Per offline conversation, this renames the existing Memory adapters as follows:
- `SteamshipPersistentConversationMemory` -> `ConversationalBufferMemory`
- `SteamshipPersistentConversationWindowMemory` -> `ConversationalBufferWindowMemory` 

Additionally, `file_handle` -> `key`.

This is intended to make the Steamship adapters easier to understand in the LangChain UX.