### PR TITLE
feat: add OpenAIChat impl with gpt-4 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-steamship==2.13.19
+steamship==2.14.0
 langchain==0.0.104
 tiktoken==0.2.0
 pydantic==1.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-steamship==2.14.0
+steamship==2.14.1
 langchain==0.0.104
 tiktoken==0.2.0
 pydantic==1.10.2


### PR DESCRIPTION
Creates a OpenAIChat implementation that can use the new `gpt-4` plugin in Steamship to interact with OpenAI's GPT-4.